### PR TITLE
Handle current working directory being the directory path

### DIFF
--- a/astParser/parser.go
+++ b/astParser/parser.go
@@ -169,11 +169,11 @@ func exprToField(fieldName string, expr ast.Expr) (*domain.Field, error) {
 
 func dotNotatedModulePath(filePath string, moduleName string) string {
 	dirPath := filepath.Dir(filePath)
-	index := strings.LastIndex(dirPath, fmt.Sprintf("/%s", moduleName))
-	// add the module name plus one place for the "/" character
-	index += len(moduleName) + 1
-	dirPath = strings.ReplaceAll(dirPath, "/", ".")
-	return dirPath[:index]
+	modulePath := strings.ReplaceAll(dirPath, "/", ".")
+	if modulePath == "." {
+		return moduleName
+	}
+	return modulePath
 }
 
 func ParseField(field *ast.Field) (*domain.Field, error) {

--- a/astParser/parser_test.go
+++ b/astParser/parser_test.go
@@ -8,6 +8,12 @@ import (
 func Test_dotNotatedModulePath(t *testing.T) {
 	assert.Equal(
 		t,
+		"models",
+		dotNotatedModulePath("address.go", "models"),
+	)
+
+	assert.Equal(
+		t,
 		"test.address.models",
 		dotNotatedModulePath("test/address/models/address.go", "models"),
 	)


### PR DESCRIPTION
Previously if you tried running `go-plantuml generate` in the context of the current working directory (as opposed to recursively walking the subdirectories), `go-plantuml` would run into a panic as captured in #6 and by running the tests:
```
$ go test ./...
?   	github.com/bykof/go-plantuml	[no test files]
--- FAIL: Test_dotNotatedModulePath (0.00s)
panic: runtime error: slice bounds out of range [:6] with length 1 [recovered]
	panic: runtime error: slice bounds out of range [:6] with length 1

goroutine 38 [running]:
testing.tRunner.func1.2({0x1023247c0, 0x1400001a240})
	/opt/homebrew/Cellar/go/1.17.3/libexec/src/testing/testing.go:1209 +0x258
testing.tRunner.func1(0x14000170ea0)
	/opt/homebrew/Cellar/go/1.17.3/libexec/src/testing/testing.go:1212 +0x284
panic({0x1023247c0, 0x1400001a240})
	/opt/homebrew/Cellar/go/1.17.3/libexec/src/runtime/panic.go:1038 +0x21c
github.com/bykof/go-plantuml/astParser.dotNotatedModulePath({0x1022ac828, 0xa}, {0x1022ab7c9, 0x6})
	/Users/joonas/go/src/github.com/joonas/go-plantuml/astParser/parser.go:176 +0x140
github.com/bykof/go-plantuml/astParser.Test_dotNotatedModulePath(0x14000170ea0)
	/Users/joonas/go/src/github.com/joonas/go-plantuml/astParser/parser_test.go:12 +0x48
testing.tRunner(0x14000170ea0, 0x102334260)
	/opt/homebrew/Cellar/go/1.17.3/libexec/src/testing/testing.go:1259 +0x104
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.17.3/libexec/src/testing/testing.go:1306 +0x328
FAIL	github.com/bykof/go-plantuml/astParser	0.267s
?   	github.com/bykof/go-plantuml/cmd	[no test files]
ok  	github.com/bykof/go-plantuml/domain	(cached)
?   	github.com/bykof/go-plantuml/formatter	[no test files]
?   	github.com/bykof/go-plantuml/test/address/models	[no test files]
?   	github.com/bykof/go-plantuml/test/user/models	[no test files]
FAIL
```

This patch simplifies the logic slightly by simply converting `dirPath` into the dot-notated module path format and checks whether the module path would simply translate to `.`, in which case we can simply return the supplied `moduleName`.

Closes #6 