### PR TITLE
Handle cases where class is not found

### DIFF
--- a/astParser/parser.go
+++ b/astParser/parser.go
@@ -103,6 +103,11 @@ func ParseFile(filePath string) domain.Classes {
 				}
 			}
 
+			// Handle the case where className could not be found in classes
+			if classIndex < 0 {
+				continue
+			}
+
 			if isPointer {
 				functionName = formatPointer(functionDecl.Name.Name)
 			} else {


### PR DESCRIPTION
This addresses the case where a function is associated with an [ast.ArrayType](https://pkg.go.dev/go/ast#ArrayType) as is the case with the [functions](https://github.com/bykof/go-plantuml/blob/master/domain/class.go#L23-L50) associated with [`domain.Classes`](https://github.com/bykof/go-plantuml/blob/master/domain/class.go#L11).

While I didn't add a test for it, it's easy enough to replicate by running the following at the root of this repository:
```
go install . && go-plantuml generate -r
```

Closes #7 