### PR TITLE
Handle cases relations to a pointer

### DIFF
--- a/domain/class.go
+++ b/domain/class.go
@@ -1,5 +1,9 @@
 package domain
 
+import (
+	"strings"
+)
+
 type (
 	Class struct {
 		Name      string
@@ -13,7 +17,12 @@ type (
 
 func (class Class) HasRelation(toClass Class) bool {
 	for _, field := range class.Fields {
-		if string(field.Type) == toClass.Name {
+		fieldTypeName := string(field.Type)
+		if strings.HasPrefix(fieldTypeName, "*") {
+			fieldTypeName = fieldTypeName[1:]
+		}
+
+		if fieldTypeName == toClass.Name {
 			return true
 		}
 	}

--- a/domain/class_test.go
+++ b/domain/class_test.go
@@ -12,15 +12,22 @@ func TestClass_HasRelation(t *testing.T) {
 	classC := Class{
 		Name: "C",
 	}
+	classD := Class{
+		Name: "D",
+	}
 	classB := Class{
 		Fields: Fields{
 			Field{
 				Type: Type("A"),
 			},
+			Field{
+				Type: Type("*D"),
+			},
 		},
 	}
 
 	assert.True(t, classB.HasRelation(classA))
+	assert.True(t, classB.HasRelation(classD))
 	assert.False(t, classB.HasRelation(classC))
 }
 


### PR DESCRIPTION
This addresses the case where a relationship from one struct to another is set up as a pointer.

I found this easiest to illustrate by changing both of the [Address references in `test/user/models/user.go`](https://github.com/bykof/go-plantuml/blob/master/test/user/models/user.go#L10-L11) to pointers, which results in the following diagram prior to this change:

![image](https://user-images.githubusercontent.com/19793/152278786-6c2baa09-57f6-45b0-a2d4-28849f24d9b8.png)

And with the change it results in what you would expect:

![image](https://user-images.githubusercontent.com/19793/152278825-7894c6fb-ae99-4a9b-b6e1-801fa3f5cca1.png)
