### PR TITLE
upgrade: go version 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bykof/go-plantuml
 
-go 1.17
+go 1.18
 
 require (
 	github.com/magiconair/properties v1.8.6


### PR DESCRIPTION
When using go mod tidy in go version 1.17, a problem occurred.

Log:
github.com/bykof/go-plantuml/astParser tested by
        github.com/bykof/go-plantuml/astParser.test imports
        github.com/stretchr/testify/assert imports
        gopkg.in/yaml.v3 tested by
        gopkg.in/yaml.v3.test imports
        gopkg.in/check.v1 loaded from gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405,
        but go 1.16 would select v1.0.0-20190902080502-41f04d3bba15

To upgrade to the versions selected by go 1.16:
        go mod tidy -go=1.16 && go mod tidy -go=1.17
If reproducibility with go 1.16 is not needed:
        go mod tidy -compat=1.17
For other options, see:
        https://golang.org/doc/modules/pruning

Solve:
Upgrade go version to 1.18.