### PR TITLE
fix format and fix problem from linter

### DIFF
--- a/astParser/formatters.go
+++ b/astParser/formatters.go
@@ -2,8 +2,9 @@ package astParser
 
 import (
 	"fmt"
-	"github.com/bykof/go-plantuml/domain"
 	"strings"
+
+	"github.com/bykof/go-plantuml/domain"
 )
 
 func formatArrayType(typeName string) string {

--- a/astParser/formatters_test.go
+++ b/astParser/formatters_test.go
@@ -1,9 +1,11 @@
 package astParser
 
 import (
-	"github.com/bykof/go-plantuml/domain"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bykof/go-plantuml/domain"
 )
 
 func Test_formatArrayType(t *testing.T) {

--- a/astParser/mapper_test.go
+++ b/astParser/mapper_test.go
@@ -1,10 +1,12 @@
 package astParser
 
 import (
-	"github.com/bykof/go-plantuml/domain"
-	"github.com/magiconair/properties/assert"
 	"go/ast"
 	"testing"
+
+	"github.com/magiconair/properties/assert"
+
+	"github.com/bykof/go-plantuml/domain"
 )
 
 func Test_starExprToField(t *testing.T) {

--- a/astParser/mappers.go
+++ b/astParser/mappers.go
@@ -1,8 +1,9 @@
 package astParser
 
 import (
-	"github.com/bykof/go-plantuml/domain"
 	"go/ast"
+
+	"github.com/bykof/go-plantuml/domain"
 )
 
 func starExprToField(fieldName string, starExpr *ast.StarExpr) domain.Field {

--- a/astParser/parser.go
+++ b/astParser/parser.go
@@ -2,7 +2,6 @@ package astParser
 
 import (
 	"fmt"
-	"github.com/bykof/go-plantuml/domain"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -11,6 +10,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	"github.com/bykof/go-plantuml/domain"
 )
 
 func ParseDirectory(directoryPath string, recursive bool) domain.Packages {

--- a/astParser/parser.go
+++ b/astParser/parser.go
@@ -5,8 +5,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -16,7 +16,7 @@ import (
 
 func ParseDirectory(directoryPath string, recursive bool) domain.Packages {
 	var packages domain.Packages
-	files, err := ioutil.ReadDir(directoryPath)
+	files, err := os.ReadDir(directoryPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"log"
+
+	"github.com/spf13/cobra"
+
 	"github.com/bykof/go-plantuml/astParser"
 	"github.com/bykof/go-plantuml/domain"
 	"github.com/bykof/go-plantuml/formatter"
-	"github.com/spf13/cobra"
-	"io/ioutil"
-	"log"
 )
 
 var (

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -31,7 +31,7 @@ var (
 			}
 
 			formattedPlantUML := formatter.FormatPlantUML(packages)
-			err := ioutil.WriteFile(outPath, []byte(formattedPlantUML), 0644)
+			err := os.WriteFile(outPath, []byte(formattedPlantUML), 0644)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 

--- a/domain/class.go
+++ b/domain/class.go
@@ -17,9 +17,8 @@ type (
 func (class Class) HasRelation(toClass Class) bool {
 	for _, field := range class.Fields {
 		fieldTypeName := string(field.Type)
-		if strings.HasPrefix(fieldTypeName, "*") {
-			fieldTypeName = fieldTypeName[1:]
-		}
+
+		fieldTypeName = strings.TrimPrefix(fieldTypeName, "*")
 
 		if fieldTypeName == toClass.Name {
 			return true

--- a/domain/class_test.go
+++ b/domain/class_test.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClass_HasRelation(t *testing.T) {

--- a/domain/field_test.go
+++ b/domain/field_test.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestField_IsPrivate(t *testing.T) {

--- a/domain/function_test.go
+++ b/domain/function_test.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFunction_IsPrivate(t *testing.T) {

--- a/domain/interface_test.go
+++ b/domain/interface_test.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInterface_IsImplementedBy(t *testing.T) {

--- a/domain/package_test.go
+++ b/domain/package_test.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPackages_AllClasses(t *testing.T) {

--- a/domain/type_test.go
+++ b/domain/type_test.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestType_ToString(t *testing.T) {

--- a/formatter/plantUml.go
+++ b/formatter/plantUml.go
@@ -2,8 +2,9 @@ package formatter
 
 import (
 	"fmt"
-	"github.com/bykof/go-plantuml/domain"
 	"strings"
+
+	"github.com/bykof/go-plantuml/domain"
 )
 
 const PlantUMLInterfaceFormat = `interface %s{

--- a/test/user/models/user.go
+++ b/test/user/models/user.go
@@ -8,7 +8,6 @@ type (
 		LastName       string
 		Age            uint8
 		Address        *models.Address
-		privateAddress models.Address
 	}
 )
 


### PR DESCRIPTION
changes: 
- format files :
  - sort imports
- fix linter problems
  - field `privateAddress` is unused
  - `S1017`: should replace this `if` statement with an unconditional `strings.TrimPrefix`
  - `SA1019`: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. 